### PR TITLE
Add target-test-base images

### DIFF
--- a/.github/workflows/build_image_target-test-base_jammy-py.yml
+++ b/.github/workflows/build_image_target-test-base_jammy-py.yml
@@ -44,24 +44,39 @@ env:
   IMAGE_ARCHS: linux/amd64,linux/arm
 
 jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Set Matrix
+      id: set-matrix
+      run: |
+        matrix='["3.8.17"]'
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event.inputs.python_3_9_17 }}" = "true" ]; then
+            matrix=$(echo $matrix | jq ' . + ["3.9.17"] ')
+          fi
+          if [ "${{ github.event.inputs.python_3_10_12 }}" = "true" ]; then
+            matrix=$(echo $matrix | jq ' . + ["3.10.12"] ')
+          fi
+          if [ "${{ github.event.inputs.python_3_11_4 }}" = "true" ]; then
+            matrix=$(echo $matrix | jq ' . + ["3.11.4"] ')
+          fi
+        fi
+        echo $matrix
+        echo "::set-output name=matrix::$matrix"
+      shell: bash
+
+
   build-and-push-docker-image:
+    needs: setup-matrix
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.8.17", "3.9.17", "3.10.12", "3.11.4"]
-        include:
-          - python_version: "3.8.17"
-            build_this_version: true
-          - python_version: "3.9.17"
-            build_this_version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python_3_9_17 == 'true' }}
-          - python_version: "3.10.12"
-            build_this_version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python_3_10_12 == 'true' }}
-          - python_version: "3.11.4"
-            build_this_version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python_3_11_4 == 'true' }}
-
+        python_version: ${{fromJson(needs.setup-matrix.outputs.matrix)}}
     steps:
       - name: Checkout Repository
-        if: matrix.build_this_version
         uses: actions/checkout@v2
 
       - name: Extract Major/Minor Version from Full Version
@@ -98,7 +113,6 @@ jobs:
             buildx-${{ matrix.python_version }}-
 
       - name: Build and Push Docker Image
-        if: matrix.build_this_version
         uses: docker/build-push-action@v2
         with:
           context: ${{ env.IMAGE_DIR }}

--- a/.github/workflows/build_image_target-test-base_jammy-py.yml
+++ b/.github/workflows/build_image_target-test-base_jammy-py.yml
@@ -1,0 +1,94 @@
+name: Build and push Docker image 'target-test-base_jammy-py'
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'target-test-base_jammy-py/**'
+      - '.github/workflows/build_image_target-test-base_jammy-py.yml'
+  pull_request:
+    paths:
+      - 'target-test-base_jammy-py/**'
+      - '.github/workflows/build_image_target-test-base_jammy-py.yml'
+  workflow_dispatch:
+    inputs:
+      python_3_8_17:
+        description: 'Python 3.8.17'
+        required: false
+        type: boolean
+        default: true
+      python_3_9_17:
+        description: 'Python 3.9.17'
+        required: false
+        type: boolean
+        default: false
+      # Add more versions as needed...
+
+env:
+  IMAGE_DIR: ./target-test-base_jammy-py
+  IMAGE_BASE_NAME: ghcr.io/${{ github.repository }}/target-test-base-jammy
+  IMAGE_ARCHS: linux/amd64,linux/arm
+
+jobs:
+  build-and-push-docker-image:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ["3.8.17", "3.9.17"] # Add more versions as needed.
+        include:
+          - python_version: "3.8.17"
+            build_this_version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python_3_8_17 == 'true' || github.event_name != 'workflow_dispatch' }}
+          - python_version: "3.9.17"
+            build_this_version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python_3_9_17 == 'true' || github.event_name != 'workflow_dispatch' }}
+
+    steps:
+      - name: Checkout Repository
+        if: matrix.build_this_version
+        uses: actions/checkout@v2
+
+      - name: Extract Major/Minor Version from Full Version
+        id: extract_version
+        run: |
+          echo "PYTHON_VERSION=${{ matrix.python_version }}" >> $GITHUB_ENV
+          echo "PYTHON_VERSION_MM=$(echo "${{ matrix.python_version }}" | cut -d'.' -f1,2)" >> $GITHUB_ENV
+
+      - name: Setup QEMU for Multi-Arch Builds
+        uses: docker/setup-qemu-action@v1
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry (GHCR)
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Docker image to use as cache (for master)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: |
+          docker pull ${{ env.IMAGE_BASE_NAME }}:py${{ matrix.python_version }} || true
+
+      - name: Cache Docker layers (for PRs)
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-${{ matrix.python_version }}-${{ github.sha }}
+          restore-keys: |
+            buildx-${{ matrix.python_version }}-
+
+      - name: Build and Push Docker Image
+        if: matrix.build_this_version
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ env.IMAGE_DIR }}
+          platforms: ${{env.IMAGE_ARCHS}}
+          tags: ${{ env.IMAGE_BASE_NAME }}:py${{ matrix.python_version }}
+          build-args: |
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            PYTHON_VERSION_MM=${{ env.PYTHON_VERSION_MM }}
+          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/build_image_target-test-base_jammy-py.yml
+++ b/.github/workflows/build_image_target-test-base_jammy-py.yml
@@ -13,16 +13,30 @@ on:
   workflow_dispatch:
     inputs:
       python_3_8_17:
-        description: 'Python 3.8.17'
+        description: 'Build Ubuntu 22.04 (Jammy) with Python 3.8.17'
         required: false
         type: boolean
         default: true
       python_3_9_17:
-        description: 'Python 3.9.17'
+        description: 'Build Ubuntu 22.04 (Jammy) with Python 3.9.17'
         required: false
         type: boolean
         default: false
-      # Add more versions as needed...
+      python_3_10_12:
+        description: 'Build Ubuntu 22.04 (Jammy) with Python 3.10.12'
+        required: false
+        type: boolean
+        default: false
+      python_3_11_4:
+        description: 'Build Ubuntu 22.04 (Jammy) with Python 3.11.4'
+        required: false
+        type: boolean
+        default: false
+
+# Kill running actions pipeline (for PR) when new changes are pushed to PR
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   IMAGE_DIR: ./target-test-base_jammy-py
@@ -34,12 +48,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.8.17", "3.9.17"] # Add more versions as needed.
+        python_version: ["3.8.17", "3.9.17", "3.10.12", "3.11.4"]
         include:
           - python_version: "3.8.17"
-            build_this_version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python_3_8_17 == 'true' || github.event_name != 'workflow_dispatch' }}
+            build_this_version: true
           - python_version: "3.9.17"
-            build_this_version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python_3_9_17 == 'true' || github.event_name != 'workflow_dispatch' }}
+            build_this_version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python_3_9_17 == 'true' }}
+          - python_version: "3.10.12"
+            build_this_version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python_3_10_12 == 'true' }}
+          - python_version: "3.11.4"
+            build_this_version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python_3_11_4 == 'true' }}
 
     steps:
       - name: Checkout Repository
@@ -89,6 +107,7 @@ jobs:
           build-args: |
             PYTHON_VERSION=${{ env.PYTHON_VERSION }}
             PYTHON_VERSION_MM=${{ env.PYTHON_VERSION_MM }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true #TODO: remove this for production
+          # push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/target-test-base_jammy-py/Dockerfile
+++ b/target-test-base_jammy-py/Dockerfile
@@ -59,4 +59,15 @@ RUN : \
 # Copy Python binaries, libraries, includes, and virtualenv from the build-python stage
 COPY --from=build-python /usr/local/ /usr/local/
 
+# Update the dynamic linker run-time bindings (Python shared libraries are not in the default search path)
+RUN ldconfig
+
+# This prefers the Espressif pypi wheel registry (https://dl.espressif.com/pypi/) over the public PyPI (fallback)
+RUN pip install --upgrade pip
+ENV PIP_INDEX_URL=https://dl.espressif.com/pypi/
+ENV PIP_EXTRA_INDEX_URL=https://pypi.org/simple
+
+# Prioritize using binary (wheel) packages over source packages for faster installations and to avoid unnecessary compilations.
+ENV PIP_PREFER_BINARY=true
+
 CMD [ "/bin/bash" ]

--- a/target-test-base_jammy-py/Dockerfile
+++ b/target-test-base_jammy-py/Dockerfile
@@ -1,0 +1,62 @@
+FROM ubuntu:22.04 AS build-python
+
+ARG PYTHON_VERSION_MM=3.8
+ARG PYTHON_VERSION=3.8.17
+
+# Install essential build tools and necessary runtime libraries for Python compilation
+RUN : \
+    && apt-get update \
+    && apt-get install -y \
+        build-essential \
+        wget \
+        libffi-dev \
+        libssl-dev \
+        zlib1g-dev \
+        liblzma-dev \
+        libbz2-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+    && :
+
+# Download, compile, and install Python from source code (to have this version available for both amd64 and armv7l)
+WORKDIR /tmp
+RUN : \
+    && wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz \
+    && tar xvf Python-${PYTHON_VERSION}.tar.xz \
+    && cd Python-${PYTHON_VERSION} \
+    && ./configure --enable-shared --enable-optimizations \
+    && make -j$(nproc) \
+    && make altinstall \
+    && :
+
+# Update symbolic links for python3 and pip3 (to be able to use commands without version suffix)
+RUN : \
+    && ln -s /usr/local/bin/python${PYTHON_VERSION_MM} /usr/local/bin/python3 \
+    && ln -s /usr/local/bin/pip${PYTHON_VERSION_MM} /usr/local/bin/pip3 \
+    && ln -s /usr/local/bin/python${PYTHON_VERSION_MM} /usr/local/bin/python \
+    && ln -s /usr/local/bin/pip${PYTHON_VERSION_MM} /usr/local/bin/pip \
+    && :
+
+# -------------------------------------------------------------------------------------------------------------------------------
+FROM ubuntu:22.04 as main
+
+# Set up required development and runtime dependencies
+RUN : \
+    && apt-get update \
+    && apt-get install -y \
+        wget \
+        libffi-dev \
+        libssl-dev \
+        zlib1g-dev \
+        liblzma-dev \
+        libbz2-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && :
+
+# Copy Python binaries, libraries, includes, and virtualenv from the build-python stage
+COPY --from=build-python /usr/local/ /usr/local/
+
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
This PR creates pre-build Docker images that can be used as base image (`FROM: ghcr.io/espressif/github-esp-dockerfiles/target-test-base-jammy:py3.8.17` for the `target-test-env` production image.  
  
The goal is to have this image ready with all Python versions for future updates in GHCR.
  
This repository is public, so image can be pulled from anywhere by anyone. Building this image on GitHub is faster and easier than doing the same on our Gitlab Docker build runner, and downloading this image does not require any token or special access.  
  
### The main features of these images  
- based on the latest Ubuntu 22.04 LTS (Jammy), with all non-default Python versions (`3.8`,  `3.9`, `3.10`, `3.11`)  
- multi-architectural, can be used on PC/VM (`amd64`) and RaspberryPI 32bit (`arm`)  
- the size of the images is relatively small (~300 MB)  
- can be used also in GitHub actions and for various local developer tests  
- the GitHub action builds all versions in parallel and stores them in GHCR  
- builds can be triggered manually on specified versions with  `workflow dispatch: `  (will work after this PR merged to master)
- `pip` prefers our registry (https://dl.espressif.com/pypi/) with Python wheels over PyPi.org (https://pypi.org/simple)
- `pip` prefers binary (wheel, even lower version) over compiling from source code
- smarter cache for image build

## Related
- (internal Gitlab MR): https://gitlab.espressif.cn:6688/idf/esp-dockerfiles/-/merge_requests/438
- (internal JIRA ticket): https://jira.espressif.com:8443/browse/RDT-510